### PR TITLE
index: only walk values if fields are not-nil

### DIFF
--- a/tfimages/tfimages.go
+++ b/tfimages/tfimages.go
@@ -55,14 +55,18 @@ func New(p tfjson.Plan, root string) (*Handler, error) {
 }
 
 func (h *Handler) Index(p tfjson.Plan) error {
-	log.Printf("walking planned values")
-	if err := h.walkModules(p.PlannedValues.RootModule); err != nil {
-		return err
+	if p.PlannedValues != nil && p.PlannedValues.RootModule != nil {
+		log.Printf("walking planned values")
+		if err := h.walkModules(p.PlannedValues.RootModule); err != nil {
+			return err
+		}
 	}
 
-	log.Printf("walking prior state")
-	if err := h.walkModules(p.PriorState.Values.RootModule); err != nil {
-		return err
+	if p.PriorState != nil && p.PriorState.Values != nil && p.PriorState.Values.RootModule != nil {
+		log.Printf("walking prior state")
+		if err := h.walkModules(p.PriorState.Values.RootModule); err != nil {
+			return err
+		}
 	}
 
 	log.Printf("%d configs, %d builds", len(h.configs), len(h.builds))


### PR DESCRIPTION
We've observed nil panics here, likely from partial data being set. It's unclear if this is expected behavior (e.g. is this always empty if there is no previous state?)

```
at .panic ( runtime/panic.go:792 )
at github.com/jonjohnsonjr/tfimages/tfimages.(*Handler).Index ( github.com/jonjohnsonjr/tfimages@v0.0.0-20250428193537-e931e46f040c/tfimages/tfimages.go:64 )
```

This change wraps the walk on a check to make sure none of the pointer fields are nil first.